### PR TITLE
Rename upload_targets to active_upload_targets

### DIFF
--- a/models/tracker/transactions.rb
+++ b/models/tracker/transactions.rb
@@ -179,7 +179,7 @@ module UniversalTracker
         upload_targets.random_target
       end
 
-      def upload_targets
+      def active_upload_targets
         upload_targets.active
       end
 


### PR DESCRIPTION
upload_targets is already defined elsewhere overshadowing this method with the same name.